### PR TITLE
Add validation for NPC before TTS update

### DIFF
--- a/lua/autorun/server/sv_gmodainpc.lua
+++ b/lua/autorun/server/sv_gmodainpc.lua
@@ -223,7 +223,7 @@ end)
 
 hook.Add("Think", "FollowNPCSound", function()
     for k, v in pairs(spawnedNPC) do
-        if v["enableTTS"] then
+        if v["enableTTS"] and IsValid(v.npc) then
             net.Start("TTSPositionUpdate")
             net.WriteString(k)
             net.WriteVector(v.npc:GetPos())


### PR DESCRIPTION
## Summary
- ensure `FollowNPCSound` checks `IsValid(v.npc)` before calling `GetPos`

## Testing
- `luac -p lua/autorun/server/sv_gmodainpc.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faa4c40b08323be78e56a1ee3d1fc